### PR TITLE
Admin SDK User/Group/Member support and misc bug-fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,28 @@ To use a specific service, inject it into your controllers by name. All GAPI met
 
 * GAPI.init()
 
-#### [**Admin Directory**](https://developers.google.com/admin-sdk/directory/v1/guides/manage-users)
+#### [**Admin Directory::users**](https://developers.google.com/admin-sdk/directory/)
 
 * Users
-  * **AdminDirectory.insertUsers(params)**
-  * **AdminDirectory.updateUsers(id, params)**
-  * **AdminDirectory.makeAdmin(id)**
-  * **AdminDirectory.unMakeAdmin(id)**
-  * **AdminDirectory.getUsers(id)**
-  * **AdminDirectory.listUsers(params)**
+  * [**AdminDirectory.insertUsers(params)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/insert)
+  * [**AdminDirectory.updateUsers(id, params)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/update)
+  * [**AdminDirectory.patchUsers(id, params)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/patch)
+  * [**AdminDirectory.deleteUsers(id, params)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/delete)
+  * [**AdminDirectory.makeAdmin(id)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/makeAdmin)
+  * [**AdminDirectory.unMakeAdmin(id)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/makeAdmin)
+  * [**AdminDirectory.getUsers(id)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/get)
+  * [**AdminDirectory.listUsers(params)**](https://developers.google.com/admin-sdk/directory/v1/reference/users/list)
+
+
+#### [**Admin Directory::groups**](https://developers.google.com/admin-sdk/directory/)
+
+* Users
+  * [**AdminDirectory.insertGroups(params)**](https://developers.google.com/admin-sdk/directory/v1/reference/groups/insert)
+  * [**AdminDirectory.updateGroups(id, params)**](https://developers.google.com/admin-sdk/directory/v1/reference/groups/update)
+  * [**AdminDirectory.patchGroups(id, params)**](https://developers.google.com/admin-sdk/directory/v1/reference/groups/patch)
+  * [**AdminDirectory.deleteGroups(id, params)**](https://developers.google.com/admin-sdk/directory/v1/reference/groups/delete)
+  * [**AdminDirectory.getGroups(id)**](https://developers.google.com/admin-sdk/directory/v1/reference/groups/get)
+  * [**AdminDirectory.listGroups(params)**](https://developers.google.com/admin-sdk/directory/v1/reference/groups/list)
 
 #### Drive
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ To use a specific service, inject it into your controllers by name. All GAPI met
 
 * GAPI.init()
 
+#### [**Admin Directory**](https://developers.google.com/admin-sdk/directory/v1/guides/manage-users)
+
+* Users
+  * **AdminDirectory.insertUsers(params)**
+  * **AdminDirectory.updateUsers(id, params)**
+  * **AdminDirectory.makeAdmin(id)**
+  * **AdminDirectory.unMakeAdmin(id)**
+  * **AdminDirectory.getUsers(id)**
+  * **AdminDirectory.listUsers(params)**
 
 #### Drive
 

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "ngGAPI",
+  "main": "gapi.js",
   "version": "0.0.0",
   "ignore": [
     "**/.*",

--- a/gapi.js
+++ b/gapi.js
@@ -739,8 +739,8 @@ angular.module('gapi', [])
   .factory('Directory', function (GAPI) {
     var Directory = new GAPI('admin/directory', 'v1', {
       users: ['get', 'insert', 'update', 'delete'],
-      groups: ['get', 'insert', 'update', 'delete', {
-          members: ['get', 'insert', 'update', 'delete', 'patch']
+      groups: ['get', 'insert', 'update', 'delete', 'list', 'patch', {
+          members: ['get', 'insert', 'update', 'delete', 'patch', 'list']
       }],
     });
 

--- a/gapi.js
+++ b/gapi.js
@@ -370,18 +370,36 @@ angular.module('gapi', [])
 
     GAPI.init = function () {
       var app = GAPI.app
-        , deferred = $q.defer();
+        , deferred = $q.defer(),
+
+        onAuth = function () {
+          app.oauthToken = gapi.auth.getToken();
+          deferred.resolve(app);
+          console.log('authorization', app)
+        };
+
+
 
       gapi.load('auth', function () {
         gapi.auth.authorize({
           client_id: app.clientId,
           scope: app.scopes,
-          immediate: false     
-        }, function() {
-          app.oauthToken = gapi.auth.getToken();
-          deferred.resolve(app);
-          console.log('authorization', app)
-        });
+          immediate: true     
+          }, function (response) {
+
+            if (response.status.signed_in === true) {
+              onAuth();
+            } else {
+
+              gapi.auth.authorize({
+                client_id: app.clientId,
+                scope: app.scopes,
+                immediate: false     
+                }, onAuth);
+            }
+
+
+          });
       });
 
       return deferred.promise;  

--- a/gapi.js
+++ b/gapi.js
@@ -8,7 +8,7 @@ angular.module('gapi', [])
    * for communicating with all google apis, and then specialize it
    * for each service.
    *
-   * The reponsibility of this general service is to implement the 
+   * The reponsibility of this general service is to implement the
    * authorization flow, and make requests on behalf of a dependent
    * API specific service.
    *
@@ -26,12 +26,11 @@ angular.module('gapi', [])
 
 
 
-  .factory('GAPI', function ($q, $http, GoogleApp) {
+  .factory('GAPI', function ($q, $http, $log, GoogleApp) {
 
     /**
      * GAPI Credentials
      */
-
     GAPI.app = GoogleApp;
 
 
@@ -62,7 +61,7 @@ angular.module('gapi', [])
      * For each resource in the provided spec, we define methods
      * for each of the its actions.
      */
-    
+
     function createMethods (service, spec, parents) {
       var resources = Object.keys(spec);
 
@@ -70,7 +69,7 @@ angular.module('gapi', [])
         var actions = spec[resource];
 
         actions.forEach(function (action) {
-          
+
           // if the action is an object, treat it as a nested
           // spec and recurse
           if (typeof action === 'object') {
@@ -82,10 +81,10 @@ angular.module('gapi', [])
             createMethods(service, action, p);
 
           } else {
-          
+
             var method = methodName(action, resource);
-            service[method] = GAPI[action](resource, parents);              
-          
+            service[method] = GAPI[action](resource, parents);
+
           }
         });
       });
@@ -111,15 +110,15 @@ angular.module('gapi', [])
 
     function oauthHeader(options) {
       if (!options.headers) { options.headers = {}; }
-      options.headers['Authorization'] = 'Bearer ' + GAPI.app.oauthToken.access_token;      
+      options.headers['Authorization'] = 'Bearer ' + GAPI.app.oauthToken.access_token;
     }
 
     function oauthParams(options) {
       if (!options.params) { options.params = {}; }
-      options.params.access_token = GAPI.app.oauthToken.access_token;      
+      options.params.access_token = GAPI.app.oauthToken.access_token;
     }
 
-    
+
     /**
      * HTTP Request Helper
      */
@@ -130,12 +129,15 @@ angular.module('gapi', [])
       oauthHeader(config);
 
       function success(response) {
-        console.log(config, response);
-        deferred.resolve(response.data);
+        $log.log('Request success: ', config, response);
+        if(response.data)
+            deferred.resolve(response.data);
+        else
+            deferred.resolve(response);
       }
 
       function failure(fault) {
-        console.log(config, fault);
+        $log.log('Request failure: ', config, fault);
         deferred.reject(fault);
       }
 
@@ -236,7 +238,7 @@ angular.module('gapi', [])
 
     function parseParams (args) {
       var last = args[(args.length - 1).toString()];
-      return (typeof last === 'object') ? last : null      
+      return (typeof last === 'object') ? last : null
     }
 
 
@@ -252,7 +254,7 @@ angular.module('gapi', [])
 
         args.forEach(function (arg, i) {
           if (!arg || typeof arg === 'object') {
-            other += 1;                         
+            other += 1;
             if (other === 1) { parsedArgs.data   = arg; }
             if (other === 2) { parsedArgs.params = arg; }
           } 
@@ -300,7 +302,7 @@ angular.module('gapi', [])
           params: parseParams(arguments)
         });
       };
-    };    
+    };
 
 
     GAPI.list = function (resource, parents) {
@@ -312,20 +314,20 @@ angular.module('gapi', [])
         });
       };
     };
-    
+
 
     GAPI.insert = function (resource, parents) {
       return function () {
         var args = parseDataParams(arguments);
         return request({
           method: 'POST',
-          url:    resourceUrl(arguments, parents, this.url, resource), 
+          url:    resourceUrl(arguments, parents, this.url, resource),
           data:   args.data,
           params: args.params
         });
       };
     };
-    
+
 
     GAPI.update = function (resource, parents) {
       return function () {
@@ -339,7 +341,7 @@ angular.module('gapi', [])
       };
     };
 
-  
+
     GAPI.patch = function (resource, parents) {
       return function () {
         var args = parseDataParams(arguments);
@@ -369,40 +371,51 @@ angular.module('gapi', [])
      */
 
     GAPI.init = function () {
-      var app = GAPI.app
-        , deferred = $q.defer(),
-
-        onAuth = function () {
-          app.oauthToken = gapi.auth.getToken();
-          deferred.resolve(app);
-          console.log('authorization', app)
-        };
-
-
-
-      gapi.load('auth', function () {
-        gapi.auth.authorize({
-          client_id: app.clientId,
-          scope: app.scopes,
-          immediate: true     
-          }, function (response) {
-
-            if (response.status.signed_in === true) {
-              onAuth();
-            } else {
-
+      var app = GAPI.app,
+        deferred = $q.defer(),
+        attemptCounter = 0,
+        onAuth = function (response) {
+          attemptCounter++;
+          if(attemptCounter > 3)
+          {
+              deferred.reject('Login attempt failed. Attempted to login ' + attemptCounter + ' times.');
+              return;
+          }
+          // The response could tell us the user is not logged in.
+          if(response && !response.error)
+          {
+              if(response.status && response.status.signed_in === true)
+              {
+                  app.oauthToken = gapi.auth.getToken();
+                  deferred.resolve(app);
+              }
+              else
+              {
+                  deferred.reject("App failed to log-in to Google API services.");
+              }
+          }
+          else
+          {
+              deferred.notify('Login attempt failed. Trying again. Attempt #' + attemptCounter);
               gapi.auth.authorize({
                 client_id: app.clientId,
                 scope: app.scopes,
-                immediate: false     
-                }, onAuth);
-            }
+                immediate: true
+                }, onAuth
+              );
+          }
+        };
 
+      deferred.notify('Trying to log-in to Google API services.');
 
-          });
-      });
+      gapi.auth.authorize({
+        client_id: app.clientId,
+        scope: app.scopes,
+        immediate: true
+        }, onAuth
+      );
 
-      return deferred.promise;  
+      return deferred.promise;
     }
 
     return GAPI;
@@ -442,7 +455,7 @@ angular.module('gapi', [])
     };
 
     Youtube.getVideoRating = function (params) {
-      return Youtube.get('videos', 'getRating', params);     
+      return Youtube.get('videos', 'getRating', params);
     };
 
     Youtube.search = function (params) {
@@ -512,17 +525,17 @@ angular.module('gapi', [])
 
 
     Blogger.publishPosts = function (blogId, postId, params) {
-      return Blogger.post('blogs', blogId, 'posts', postId, 'publish', undefined, params);      
+      return Blogger.post('blogs', blogId, 'posts', postId, 'publish', undefined, params);
     };
 
 
     Blogger.revertPosts = function (blogId, postId) {
-      return Blogger.post('blogs', blogId, 'posts', postId, 'revert');    
+      return Blogger.post('blogs', blogId, 'posts', postId, 'revert');
     };
 
 
     Blogger.getBlogUserInfos = function (userId, blogId, params) {
-      return Blogger.get('users', userId, 'blogs', blogId, params);     
+      return Blogger.get('users', userId, 'blogs', blogId, params);
     };
 
 
@@ -530,14 +543,14 @@ angular.module('gapi', [])
       return Blogger.get('blogs', blogId, 'pageviews', params);
     };
 
-    
+
     Blogger.getPostUserInfos = function (userId, blogId, postId, params) {
       return Blogger.get('users', userId, 'blogs', blogId, 'posts', postId, params);
     };
 
 
     Blogger.listPostUserInfos = function (userId, blogId, params) {
-      return Blogger.get('users', userId, 'blogs', blogId, 'posts', params); 
+      return Blogger.get('users', userId, 'blogs', blogId, 'posts', params);
     };
 
 
@@ -608,7 +621,7 @@ angular.module('gapi', [])
     var Drive = new GAPI('drive', 'v2', {
       files:          ['get', 'list', 'insert', 'update', 'delete', 'patch', {
         children:     ['get', 'list', 'insert', 'delete'],
-        parents:      ['get', 'list', 'insert', 'delete'],        
+        parents:      ['get', 'list', 'insert', 'delete'],
         permissions:  ['get', 'list', 'insert', 'update', 'delete', 'patch'],
         revisions:    ['get', 'list', 'update', 'delete', 'patch'],
         comments:     ['get', 'list', 'insert', 'update', 'delete', 'patch', {
@@ -626,7 +639,7 @@ angular.module('gapi', [])
     };
 
     Drive.touchFile   = function (fileId) {
-      return Drive.post('files', fileId, 'touch');  
+      return Drive.post('files', fileId, 'touch');
     };
 
     Drive.trashFile   = function (fileId) {
@@ -634,7 +647,7 @@ angular.module('gapi', [])
     };
 
     Drive.untrashFile = function (fileId) {
-      return Drive.post('files', fileId, 'untrash');      
+      return Drive.post('files', fileId, 'untrash');
     };
 
     Drive.watchFile   = function (fileId, data) {
@@ -659,7 +672,7 @@ angular.module('gapi', [])
 
     Drive.updateRealtime = function (fileId, params) {
       return GAPI.request({
-        method: 'PUT', 
+        method: 'PUT',
         url:    Drive.url + ['files', fileId, 'realtime'].join('/'),
         params: params
       });
@@ -681,18 +694,18 @@ angular.module('gapi', [])
       }],
       activities:   ['get', {
         comments:   ['list']
-      }], 
+      }],
       comments:     ['get']
     });
 
     Plus.searchPeople = function (params) {
-      return Plus.get('people', params);  
+      return Plus.get('people', params);
     };
 
     Plus.listPeopleByActivity = function (activityId, collection, params) {
-      return Plus.get('activities', activityId, 'people', collection, params);    
+      return Plus.get('activities', activityId, 'people', collection, params);
     };
-    
+
     Plus.listPeople = function (userId, collection, params) {
       return Plus.get('people', userId, 'people', collection, params);
     }
@@ -702,7 +715,7 @@ angular.module('gapi', [])
     };
 
     Plus.insertMoments = function (userId, collection, data, params) {
-      return Plus.post('people', userId, 'moments', collection, data, params);      
+      return Plus.post('people', userId, 'moments', collection, data, params);
     };
 
     Plus.listMoments = function (userId, collection, params) {
@@ -720,28 +733,31 @@ angular.module('gapi', [])
   })
 
   /**
-   * Calendar API
+   * Admin Directory API
    */
 
-  .factory('AdminDirectory', function (GAPI) {
-    var AdminDirectory = new GAPI('admin/directory', 'v1', {
+  .factory('Directory', function (GAPI) {
+    var Directory = new GAPI('admin/directory', 'v1', {
       users: ['get', 'insert', 'update', 'delete'],
+      groups: ['get', 'insert', 'update', 'delete', {
+          members: ['get', 'insert', 'update', 'delete', 'patch']
+      }],
     });
 
-    AdminDirectory.makeAdmin = function (id) {
+    Directory.makeAdmin = function (id) {
       var data = {'status':true};
-      return AdminDirectory.post('users', id, 'makeAdmin', data);
+      return Directory.post('users', id, 'makeAdmin', data);
     };
 
-    AdminDirectory.unMakeAdmin = function (id) {
+    Directory.unMakeAdmin = function (id) {
       var data = {'status':false};
-      return AdminDirectory.post('users', id, 'makeAdmin', data);
+      return Directory.post('users', id, 'makeAdmin', data);
     };
 
-    AdminDirectory.listUsers = function (params) {
-      return AdminDirectory.get('users', params);
+    Directory.listUsers = function (params) {
+      return Directory.get('users', params);
     };
 
-    return AdminDirectory;
+    return Directory;
   })
 

--- a/gapi.js
+++ b/gapi.js
@@ -200,7 +200,7 @@ angular.module('gapi', [])
         url:    this.url + path.join('/'),
         data:   data,
         params: params
-      });            
+      });
     }
 
 
@@ -713,8 +713,35 @@ angular.module('gapi', [])
       return GAPI.request({
         method: 'DELETE',
         url:    Plus.url + ['moments', id].join('/')
-      });       
+      });
     };
 
     return Plus;
   })
+
+  /**
+   * Calendar API
+   */
+
+  .factory('AdminDirectory', function (GAPI) {
+    var AdminDirectory = new GAPI('admin/directory', 'v1', {
+      users: ['get', 'insert', 'update', 'delete'],
+    });
+
+    AdminDirectory.makeAdmin = function (id) {
+      var data = {'status':true};
+      return AdminDirectory.post('users', id, 'makeAdmin', data);
+    };
+
+    AdminDirectory.unMakeAdmin = function (id) {
+      var data = {'status':false};
+      return AdminDirectory.post('users', id, 'makeAdmin', data);
+    };
+
+    AdminDirectory.listUsers = function (params) {
+      return AdminDirectory.get('users', params);
+    };
+
+    return AdminDirectory;
+  })
+

--- a/gapi.js
+++ b/gapi.js
@@ -376,26 +376,19 @@ angular.module('gapi', [])
         attemptCounter = 0,
         onAuth = function (response) {
           attemptCounter++;
-          if(attemptCounter > 3)
-          {
+          if(attemptCounter > 3) {
               deferred.reject('Login attempt failed. Attempted to login ' + attemptCounter + ' times.');
               return;
           }
           // The response could tell us the user is not logged in.
-          if(response && !response.error)
-          {
-              if(response.status && response.status.signed_in === true)
-              {
+          if(response && !response.error) {
+              if(response.status && response.status.signed_in === true) {
                   app.oauthToken = gapi.auth.getToken();
                   deferred.resolve(app);
-              }
-              else
-              {
+              } else {
                   deferred.reject("App failed to log-in to Google API services.");
               }
-          }
-          else
-          {
+          } else {
               deferred.notify('Login attempt failed. Trying again. Attempt #' + attemptCounter);
               gapi.auth.authorize({
                 client_id: app.clientId,
@@ -731,6 +724,7 @@ angular.module('gapi', [])
 
     return Plus;
   })
+
 
   /**
    * Admin Directory API

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -53,7 +53,7 @@ module.exports = function(config) {
     // - Safari (only Mac)
     // - PhantomJS
     // - IE (only Windows)
-    browsers: ['Chrome'],
+    browsers: ['PhantomJS'],
 
 
     // If browser does not capture in given timeout [ms], kill it
@@ -62,6 +62,12 @@ module.exports = function(config) {
     preprocessors: {
       '**/*.coffee': 'coffee'
     },
+
+    plugins: [
+      'karma-jasmine',
+      'karma-phantomjs-launcher',
+      'karma-coffee-preprocessor'
+    ],
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit

--- a/test/spec/AdminSpec.coffee
+++ b/test/spec/AdminSpec.coffee
@@ -1,0 +1,117 @@
+describe 'GAPI', ->
+
+  { 
+    GAPI,AdminDirectory,
+    $httpBackend,baseUrl,
+    getHeaders,postHeaders,putHeaders,deleteHeaders,patchHeaders,noContentHeaders
+    authorization
+  } = {}
+
+
+  angular.module('gapi')
+    .value 'GoogleApp', 
+      apiKey: '1234'
+      clientId: 'abcd'
+
+
+  beforeEach module 'gapi'
+
+
+  beforeEach inject ($injector) ->
+    GAPI         = $injector.get 'GAPI'
+    $httpBackend = $injector.get '$httpBackend'
+    $log         = $injector.get '$log'
+
+    GAPI.app = {
+      oauthToken: {
+        access_token: '1234abcd'
+      }
+    }
+
+    getHeaders = deleteHeaders = patchHeaders = noContentHeaders =
+      "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+
+    postHeaders = putHeaders =
+      "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
+
+
+  afterEach ->
+    $httpBackend.verifyNoOutstandingExpectation()
+    $httpBackend.verifyNoOutstandingRequest()
+
+
+  describe 'AdminDirectory', ->
+
+    beforeEach inject ($injector) ->
+      AdminDirectory = $injector.get('AdminDirectory')
+
+
+    # SERVICE PROPERTIES
+
+    it 'should refer to the AdminDirectory api', ->
+      expect(AdminDirectory.api).toBe 'admin/directory'
+
+    it 'should refer to version 1', ->
+      expect(AdminDirectory.version).toBe 'v1'
+
+    it 'should refer to the correct url', ->
+      expect(AdminDirectory.url).toBe 'https://www.googleapis.com/admin/directory/v1/'
+
+
+    # Users
+
+    it 'should create a user', ->
+      url = "#{AdminDirectory.url}users"
+      data = { "primaryEmail": "liz@example.com", "name": { "givenName": "Elizabeth", "familyName": "Smith" }, "suspended": false, "password": "new user password", "hashFunction": "SHA-1", "changePasswordAtNextLogin": false, "ipWhitelisted": false, "ims": [ { "type": "work", "protocol": "gtalk", "im": "liz_im@talk.example.com", "primary": true } ], "emails": [ { "address": "liz@example.com", "type": "home", "customType": "", "primary": true } ], "addresses": [ { "type": "work", "customType": "", "streetAddress": "1600 Amphitheatre Parkway", "locality": "Mountain View", "region": "CA", "postalCode": "94043" } ], "externalIds": [ { "value": "12345", "type": "custom", "customType": "employee" } ], "relations": [ { "value": "Mom", "type": "mother", "customType": "" }, { "value": "manager", "type": "referred_by", "customType": "" } ], "organizations": [ { "name": "Google Inc.", "title": "SWE", "primary": true, "type": "work", "description": "Software engineer" } ], "phones": [ { "value": "+1 nnn nnn nnnn", "type": "work" } ], "orgUnitPath": "/corp/engineering", "includeInGlobalAddressList": true }
+      $httpBackend.expectPOST(url, data, postHeaders).respond null
+      AdminDirectory.insertUsers data
+      $httpBackend.flush()
+
+    it 'should update a user', ->
+      url = "#{AdminDirectory.url}users/123"
+      data = { "primaryEmail": "liz@example.com", "name": { "givenName": "Elizabeth", "familyName": "Smith" }, "suspended": false, "password": "new user password", "hashFunction": "SHA-1", "changePasswordAtNextLogin": false, "ipWhitelisted": false, "ims": [ { "type": "work", "protocol": "gtalk", "im": "liz_im@talk.example.com", "primary": true } ], "emails": [ { "address": "liz@example.com", "type": "home", "customType": "", "primary": true } ], "addresses": [ { "type": "work", "customType": "", "streetAddress": "1600 Amphitheatre Parkway", "locality": "Mountain View", "region": "CA", "postalCode": "94043" } ], "externalIds": [ { "value": "12345", "type": "custom", "customType": "employee" } ], "relations": [ { "value": "Mom", "type": "mother", "customType": "" }, { "value": "manager", "type": "referred_by", "customType": "" } ], "organizations": [ { "name": "Google Inc.", "title": "SWE", "primary": true, "type": "work", "description": "Software engineer" } ], "phones": [ { "value": "+1 nnn nnn nnnn", "type": "work" } ], "orgUnitPath": "/corp/engineering", "includeInGlobalAddressList": true }
+      $httpBackend.expectPUT(url, data, putHeaders).respond null
+      AdminDirectory.updateUsers '123', data
+      $httpBackend.flush()
+
+    it 'should make a user an administrator', ->
+      url = "#{AdminDirectory.url}users/123/makeAdmin"
+      data = { "status": true }
+      $httpBackend.expectPOST(url, data, postHeaders).respond null
+      AdminDirectory.makeAdmin '123'
+      $httpBackend.flush()
+
+    it 'should make an administrator a user', ->
+      url = "#{AdminDirectory.url}users/123/makeAdmin"
+      data = { "status": false }
+      $httpBackend.expectPOST(url, data, postHeaders).respond null
+      AdminDirectory.unMakeAdmin '123'
+      $httpBackend.flush()
+
+    it 'should get a user', ->
+      url = "#{AdminDirectory.url}users/123"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      AdminDirectory.getUsers '123'
+      $httpBackend.flush()
+
+    it 'should get a user', ->
+      url = "#{AdminDirectory.url}users/123"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      AdminDirectory.getUsers '123'
+      $httpBackend.flush()
+
+    it 'should list all users in a domain', ->
+      url = "#{AdminDirectory.url}users?domain=example.com"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      AdminDirectory.listUsers {'domain':'example.com'}
+      $httpBackend.flush()
+
+    it 'should list all users in an account', ->
+      url = "#{AdminDirectory.url}users?customer=1234&maxResults=20&orderBy=familyName&pageToken=pageToken&query=email%3Dsomeone@example.com&sortOrder=descending"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      AdminDirectory.listUsers {'customer':'1234','maxResults':20,'orderBy':'familyName','pageToken':'pageToken','query':'email=someone@example.com','sortOrder':'descending'}
+      $httpBackend.flush()
+

--- a/test/spec/BloggerSpec.coffee
+++ b/test/spec/BloggerSpec.coffee
@@ -1,6 +1,6 @@
 describe 'GAPI', ->
 
-  { 
+  {
     GAPI,Blogger,
     $httpBackend,baseUrl,
     getHeaders,postHeaders,putHeaders,deleteHeaders,patchHeaders,noContentHeaders,
@@ -9,10 +9,10 @@ describe 'GAPI', ->
 
 
   angular.module('gapi')
-    .value 'GoogleApp', 
+    .value 'GoogleApp',
       apiKey: '1234'
       clientId: 'abcd'
-    
+
 
   beforeEach module 'gapi'
 
@@ -27,16 +27,19 @@ describe 'GAPI', ->
       }
     }
 
-    getHeaders = deleteHeaders = patchHeaders = noContentHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
+    getHeaders = deleteHeaders = noContentHeaders =
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+
+    patchHeaders =
+      "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
     postHeaders = putHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
-      "Content-Type":"application/json;charset=utf-8"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
 
   afterEach ->
@@ -64,7 +67,7 @@ describe 'GAPI', ->
     it 'should get blog by id', ->
       url = "#{Blogger.url}blogs/xyz"
       $httpBackend.expectGET(url, getHeaders).respond null
-      Blogger.getBlogs 'xyz' 
+      Blogger.getBlogs 'xyz'
       $httpBackend.flush()
 
     it 'should get blog by url', ->
@@ -98,7 +101,7 @@ describe 'GAPI', ->
       url = "#{Blogger.url}blogs/123/posts/456/comments/789/approve"
       $httpBackend.expectPOST(url, undefined, noContentHeaders).respond null
       Blogger.approveComments '123', '456', '789'
-      $httpBackend.flush()      
+      $httpBackend.flush()
 
     it 'should delete a comment', ->
       url = "#{Blogger.url}blogs/123/posts/456/comments/789"
@@ -126,7 +129,7 @@ describe 'GAPI', ->
 
 
     # PAGES
-    
+
     it 'should list pages', ->
       url = "#{Blogger.url}blogs/123/pages?fetchBodies=true"
       $httpBackend.expectGET(url, getHeaders).respond null
@@ -147,30 +150,30 @@ describe 'GAPI', ->
 
     it 'should insert a page', ->
       url = "#{Blogger.url}blogs/123/pages"
-      data =   
+      data =
         title: 'string'
         content: 'string'
       $httpBackend.expectPOST(url, data, postHeaders).respond null
       Blogger.insertPages '123', data
-      $httpBackend.flush() 
+      $httpBackend.flush()
 
     it 'should patch a page', ->
       url = "#{Blogger.url}blogs/123/pages/456"
-      data =   
+      data =
         title: 'string'
-        content: 'string'      
+        content: 'string'
       $httpBackend.expectPATCH(url, data, patchHeaders).respond null
       Blogger.patchPages '123', '456', data
-      $httpBackend.flush() 
+      $httpBackend.flush()
 
     it 'should update a page', ->
       url = "#{Blogger.url}blogs/123/pages/456"
-      data =   
+      data =
         title: 'string'
-        content: 'string'      
+        content: 'string'
       $httpBackend.expectPUT(url, data, putHeaders).respond null
       Blogger.updatePages '123', '456', data
-      $httpBackend.flush() 
+      $httpBackend.flush()
 
 
     # POSTS
@@ -195,7 +198,7 @@ describe 'GAPI', ->
 
     it 'should insert a post', ->
       url = "#{Blogger.url}blogs/123/posts?isDraft=true"
-      data =   
+      data =
         title: 'string'
         content: 'string'
       $httpBackend.expectPOST(url, data, postHeaders).respond null
@@ -216,21 +219,21 @@ describe 'GAPI', ->
 
     it 'should patch a post', ->
       url = "#{Blogger.url}blogs/123/posts/456"
-      data =   
+      data =
         title: 'string'
-        content: 'string'      
+        content: 'string'
       $httpBackend.expectPATCH(url, data, patchHeaders).respond null
       Blogger.patchPosts '123', '456', data
-      $httpBackend.flush() 
+      $httpBackend.flush()
 
     it 'should update a post', ->
       url = "#{Blogger.url}blogs/123/posts/456"
-      data =   
+      data =
         title: 'string'
-        content: 'string'      
+        content: 'string'
       $httpBackend.expectPUT(url, data, putHeaders).respond null
       Blogger.updatePosts '123', '456', data
-      $httpBackend.flush() 
+      $httpBackend.flush()
 
     it 'should publish a post', ->
       url = "#{Blogger.url}blogs/123/posts/456/publish?publishDate=datetime"
@@ -264,7 +267,7 @@ describe 'GAPI', ->
 
 
     # PAGEVIEWS
-    
+
     it 'should get pageviews for a blog', ->
       url = "#{Blogger.url}blogs/123/pageviews?range=all"
       $httpBackend.expectGET(url, getHeaders).respond null

--- a/test/spec/CalendarSpec.coffee
+++ b/test/spec/CalendarSpec.coffee
@@ -1,6 +1,6 @@
 describe 'GAPI', ->
 
-  { 
+  {
     GAPI,Calendar,
     $httpBackend,baseUrl,
     getHeaders,postHeaders,putHeaders,deleteHeaders,patchHeaders,noContentHeaders
@@ -9,11 +9,11 @@ describe 'GAPI', ->
 
 
   angular.module('gapi')
-    .value 'GoogleApp', 
+    .value 'GoogleApp',
       apiKey: '1234'
       clientId: 'abcd'
 
-    
+
   beforeEach module 'gapi'
 
 
@@ -27,16 +27,19 @@ describe 'GAPI', ->
       }
     }
 
-    getHeaders = deleteHeaders = patchHeaders = noContentHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
+    getHeaders = deleteHeaders = noContentHeaders =
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+
+    patchHeaders =
+      "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
     postHeaders = putHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
-      "Content-Type":"application/json;charset=utf-8"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
 
   afterEach ->
@@ -74,14 +77,14 @@ describe 'GAPI', ->
       url = "#{Calendar.url}calendars/123/acl/456"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.getAcl '123', '456'
-      $httpBackend.flush()      
+      $httpBackend.flush()
 
     it 'should insert an acl', ->
       url = "#{Calendar.url}calendars/123/acl"
       data = { role: 'owner', scope: { type: 'user' } }
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      Calendar.insertAcl '123', data 
-      $httpBackend.flush()    
+      Calendar.insertAcl '123', data
+      $httpBackend.flush()
 
     it 'should list an acl', ->
       url = "#{Calendar.url}calendars/123/acl"
@@ -94,14 +97,14 @@ describe 'GAPI', ->
       data = { role: 'writer' }
       $httpBackend.expectPUT(url, data, postHeaders).respond null
       Calendar.updateAcl '123', '456', data
-      $httpBackend.flush()    
+      $httpBackend.flush()
 
     it 'should patch an acl', ->
       url = "#{Calendar.url}calendars/123/acl/456"
       data = { role: 'reader' }
       $httpBackend.expectPATCH(url, data, patchHeaders).respond null
       Calendar.patchAcl '123', '456', data
-      $httpBackend.flush()      
+      $httpBackend.flush()
 
 
     # CALENDAR LIST
@@ -116,7 +119,7 @@ describe 'GAPI', ->
       url = "#{Calendar.url}users/me/calendarList/xyz"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.getCalendarList 'xyz'
-      $httpBackend.flush()    
+      $httpBackend.flush()
 
     it 'should insert a calendar list', ->
       url = "#{Calendar.url}users/me/calendarList"
@@ -129,7 +132,7 @@ describe 'GAPI', ->
       url = "#{Calendar.url}users/me/calendarList?maxResults=5"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.listCalendarList { maxResults: 5 }
-      $httpBackend.flush()   
+      $httpBackend.flush()
 
     it 'should update a calendar list', ->
       url = "#{Calendar.url}users/me/calendarList/xyz"
@@ -209,60 +212,60 @@ describe 'GAPI', ->
       url = "#{Calendar.url}calendars/123/events/456"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.getEvents '123', '456'
-      $httpBackend.flush()    
+      $httpBackend.flush()
 
     it 'should import an event', ->
       url = "#{Calendar.url}calendars/123/events/import"
       data = { attendees: ['joe@example.com'], start: {}, end: {} }
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      Calendar.importEvents '123', data 
-      $httpBackend.flush()   
+      Calendar.importEvents '123', data
+      $httpBackend.flush()
 
     it 'should insert an event', ->
       url = "#{Calendar.url}calendars/123/events"
       data = { attendees: ['joe@example.com'], start: {}, end: {} }
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      Calendar.insertEvents '123', data 
-      $httpBackend.flush()      
-    
+      Calendar.insertEvents '123', data
+      $httpBackend.flush()
+
     it 'should list instances of a recurring event', ->
       url = "#{Calendar.url}calendars/123/events/456/instances"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.listEventInstances '123', '456'
-      $httpBackend.flush()       
+      $httpBackend.flush()
 
     it 'should list events on a specified calendar', ->
       url = "#{Calendar.url}calendars/123/events"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.listEvents '123'
-      $httpBackend.flush()    
+      $httpBackend.flush()
 
     it 'should move an event to another calendar', ->
       url = "#{Calendar.url}calendars/123/events/456/move?destination=124"
       $httpBackend.expectPOST(url, undefined, noContentHeaders).respond null
       Calendar.moveEvents '123', '456', '124'
-      $httpBackend.flush()   
+      $httpBackend.flush()
 
     it 'should create an event based on a simple text string', ->
       text = 'Appointment at Somewhere on June 3rd 10am-10:25am'
-      url = "#{Calendar.url}calendars/123/events/quickAdd?text=#{encodeURIComponent(text)}"
+      url = "#{Calendar.url}calendars/123/events/quickAdd?text=Appointment+at+Somewhere+on+June+3rd+10am-10:25am"
       $httpBackend.expectPOST(url, undefined, noContentHeaders).respond null
       Calendar.quickAdd '123', {text}
-      $httpBackend.flush()   
+      $httpBackend.flush()
 
     it 'should update an event', ->
       url = "#{Calendar.url}calendars/123/events/456"
       data = { attendees: ['joe@example.com'], start: {}, end: {} }
       $httpBackend.expectPUT(url, data, postHeaders).respond null
       Calendar.updateEvents '123', '456', data
-      $httpBackend.flush()     
+      $httpBackend.flush()
 
     it 'should patch an event', ->
       url = "#{Calendar.url}calendars/123/events/456"
       data = { attendees: ['joe@example.com'], start: {}, end: {} }
       $httpBackend.expectPATCH(url, data, patchHeaders).respond null
       Calendar.patchEvents '123', '456', data
-      $httpBackend.flush()  
+      $httpBackend.flush()
 
     it 'should watch for changes to events', ->
       url = "#{Calendar.url}calendars/123/events/watch"
@@ -274,9 +277,9 @@ describe 'GAPI', ->
         params:
           ttl: 'string'
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      Calendar.watchEvents '123', data 
+      Calendar.watchEvents '123', data
       $httpBackend.flush()
-    
+
 
     # FREEBUSY
 
@@ -288,7 +291,7 @@ describe 'GAPI', ->
         timeZone: 'string',
         groupExpansionMax: 'integer',
         calendarExpansionMax: 'integer',
-        items: 
+        items:
           id: 'string'
       $httpBackend.expectPOST(url, data, postHeaders).respond null
       Calendar.freeBusy(data)
@@ -301,13 +304,13 @@ describe 'GAPI', ->
       url = "#{Calendar.url}users/me/settings/xyz"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.getSettings 'xyz'
-      $httpBackend.flush()  
+      $httpBackend.flush()
 
     it 'should list user settings for the authenticated user', ->
       url = "#{Calendar.url}users/me/settings"
       $httpBackend.expectGET(url, getHeaders).respond null
       Calendar.listSettings()
-      $httpBackend.flush() 
+      $httpBackend.flush()
 
 
     # CHANNELS
@@ -316,5 +319,5 @@ describe 'GAPI', ->
       url = "#{Calendar.url}channels/stop"
       data = { id: 'string', resourceId: 'string' }
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      Calendar.stopWatching data 
-      $httpBackend.flush()       
+      Calendar.stopWatching data
+      $httpBackend.flush()

--- a/test/spec/DirectorySpec.coffee
+++ b/test/spec/DirectorySpec.coffee
@@ -1,7 +1,7 @@
 describe 'GAPI', ->
 
   { 
-    GAPI,AdminDirectory,
+    GAPI,Directory,
     $httpBackend,baseUrl,
     getHeaders,postHeaders,putHeaders,deleteHeaders,patchHeaders,noContentHeaders
     authorization
@@ -43,75 +43,75 @@ describe 'GAPI', ->
     $httpBackend.verifyNoOutstandingRequest()
 
 
-  describe 'AdminDirectory', ->
+  describe 'Directory', ->
 
     beforeEach inject ($injector) ->
-      AdminDirectory = $injector.get('AdminDirectory')
+      Directory = $injector.get('Directory')
 
 
     # SERVICE PROPERTIES
 
-    it 'should refer to the AdminDirectory api', ->
-      expect(AdminDirectory.api).toBe 'admin/directory'
+    it 'should refer to the Directory api', ->
+      expect(Directory.api).toBe 'admin/directory'
 
     it 'should refer to version 1', ->
-      expect(AdminDirectory.version).toBe 'v1'
+      expect(Directory.version).toBe 'v1'
 
     it 'should refer to the correct url', ->
-      expect(AdminDirectory.url).toBe 'https://www.googleapis.com/admin/directory/v1/'
+      expect(Directory.url).toBe 'https://www.googleapis.com/admin/directory/v1/'
 
 
     # Users
 
     it 'should create a user', ->
-      url = "#{AdminDirectory.url}users"
+      url = "#{Directory.url}users"
       data = { "primaryEmail": "liz@example.com", "name": { "givenName": "Elizabeth", "familyName": "Smith" }, "suspended": false, "password": "new user password", "hashFunction": "SHA-1", "changePasswordAtNextLogin": false, "ipWhitelisted": false, "ims": [ { "type": "work", "protocol": "gtalk", "im": "liz_im@talk.example.com", "primary": true } ], "emails": [ { "address": "liz@example.com", "type": "home", "customType": "", "primary": true } ], "addresses": [ { "type": "work", "customType": "", "streetAddress": "1600 Amphitheatre Parkway", "locality": "Mountain View", "region": "CA", "postalCode": "94043" } ], "externalIds": [ { "value": "12345", "type": "custom", "customType": "employee" } ], "relations": [ { "value": "Mom", "type": "mother", "customType": "" }, { "value": "manager", "type": "referred_by", "customType": "" } ], "organizations": [ { "name": "Google Inc.", "title": "SWE", "primary": true, "type": "work", "description": "Software engineer" } ], "phones": [ { "value": "+1 nnn nnn nnnn", "type": "work" } ], "orgUnitPath": "/corp/engineering", "includeInGlobalAddressList": true }
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      AdminDirectory.insertUsers data
+      Directory.insertUsers data
       $httpBackend.flush()
 
     it 'should update a user', ->
-      url = "#{AdminDirectory.url}users/123"
+      url = "#{Directory.url}users/123"
       data = { "primaryEmail": "liz@example.com", "name": { "givenName": "Elizabeth", "familyName": "Smith" }, "suspended": false, "password": "new user password", "hashFunction": "SHA-1", "changePasswordAtNextLogin": false, "ipWhitelisted": false, "ims": [ { "type": "work", "protocol": "gtalk", "im": "liz_im@talk.example.com", "primary": true } ], "emails": [ { "address": "liz@example.com", "type": "home", "customType": "", "primary": true } ], "addresses": [ { "type": "work", "customType": "", "streetAddress": "1600 Amphitheatre Parkway", "locality": "Mountain View", "region": "CA", "postalCode": "94043" } ], "externalIds": [ { "value": "12345", "type": "custom", "customType": "employee" } ], "relations": [ { "value": "Mom", "type": "mother", "customType": "" }, { "value": "manager", "type": "referred_by", "customType": "" } ], "organizations": [ { "name": "Google Inc.", "title": "SWE", "primary": true, "type": "work", "description": "Software engineer" } ], "phones": [ { "value": "+1 nnn nnn nnnn", "type": "work" } ], "orgUnitPath": "/corp/engineering", "includeInGlobalAddressList": true }
       $httpBackend.expectPUT(url, data, putHeaders).respond null
-      AdminDirectory.updateUsers '123', data
+      Directory.updateUsers '123', data
       $httpBackend.flush()
 
     it 'should make a user an administrator', ->
-      url = "#{AdminDirectory.url}users/123/makeAdmin"
+      url = "#{Directory.url}users/123/makeAdmin"
       data = { "status": true }
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      AdminDirectory.makeAdmin '123'
+      Directory.makeAdmin '123'
       $httpBackend.flush()
 
     it 'should make an administrator a user', ->
-      url = "#{AdminDirectory.url}users/123/makeAdmin"
+      url = "#{Directory.url}users/123/makeAdmin"
       data = { "status": false }
       $httpBackend.expectPOST(url, data, postHeaders).respond null
-      AdminDirectory.unMakeAdmin '123'
+      Directory.unMakeAdmin '123'
       $httpBackend.flush()
 
     it 'should get a user', ->
-      url = "#{AdminDirectory.url}users/123"
+      url = "#{Directory.url}users/123"
       $httpBackend.expectGET(url, getHeaders).respond null
-      AdminDirectory.getUsers '123'
+      Directory.getUsers '123'
       $httpBackend.flush()
 
     it 'should get a user', ->
-      url = "#{AdminDirectory.url}users/123"
+      url = "#{Directory.url}users/123"
       $httpBackend.expectGET(url, getHeaders).respond null
-      AdminDirectory.getUsers '123'
+      Directory.getUsers '123'
       $httpBackend.flush()
 
     it 'should list all users in a domain', ->
-      url = "#{AdminDirectory.url}users?domain=example.com"
+      url = "#{Directory.url}users?domain=example.com"
       $httpBackend.expectGET(url, getHeaders).respond null
-      AdminDirectory.listUsers {'domain':'example.com'}
+      Directory.listUsers {'domain':'example.com'}
       $httpBackend.flush()
 
     it 'should list all users in an account', ->
-      url = "#{AdminDirectory.url}users?customer=1234&maxResults=20&orderBy=familyName&pageToken=pageToken&query=email%3Dsomeone@example.com&sortOrder=descending"
+      url = "#{Directory.url}users?customer=1234&maxResults=20&orderBy=familyName&pageToken=pageToken&query=email%3Dsomeone@example.com&sortOrder=descending"
       $httpBackend.expectGET(url, getHeaders).respond null
-      AdminDirectory.listUsers {'customer':'1234','maxResults':20,'orderBy':'familyName','pageToken':'pageToken','query':'email=someone@example.com','sortOrder':'descending'}
+      Directory.listUsers {'customer':'1234','maxResults':20,'orderBy':'familyName','pageToken':'pageToken','query':'email=someone@example.com','sortOrder':'descending'}
       $httpBackend.flush()
 

--- a/test/spec/DirectorySpec.coffee
+++ b/test/spec/DirectorySpec.coffee
@@ -115,3 +115,85 @@ describe 'GAPI', ->
       Directory.listUsers {'customer':'1234','maxResults':20,'orderBy':'familyName','pageToken':'pageToken','query':'email=someone@example.com','sortOrder':'descending'}
       $httpBackend.flush()
 
+    # Groups
+
+    it 'should create a group', ->
+      url = "#{Directory.url}groups"
+      data = { "email": "testgroup@mydomain.com", "name": "Test Group", "description": "Test Group Long Description" };
+      $httpBackend.expectPOST(url, data, postHeaders).respond null
+      Directory.insertGroups data
+      $httpBackend.flush()
+
+    it 'should update a group', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com"
+      data = { "email": "testgroup@mydomain.com", "name": "Test Group", "description": "Test Group Long Description" };
+      $httpBackend.expectPUT(url, data, putHeaders).respond null
+      Directory.updateGroups 'testgroup@mydomain.com', data
+      $httpBackend.flush()
+
+    it 'should patch a group', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com"
+      data = { "email": "testgroup@mydomain.com", "description": "Test Group Long Description" };
+      $httpBackend.expectPATCH(url, data, putHeaders).respond null
+      Directory.patchGroups 'testgroup@mydomain.com', data
+      $httpBackend.flush()
+
+    it 'should get a group', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      Directory.getGroups 'testgroup@mydomain.com'
+      $httpBackend.flush()
+
+    it 'should list all groups', ->
+      url = "#{Directory.url}groups?domain=example.com"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      Directory.listGroups {'domain':'example.com'}
+      $httpBackend.flush()
+
+    it 'should delete a group', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com"
+      $httpBackend.expectDELETE(url, getHeaders).respond null
+      Directory.deleteGroups 'testgroup@mydomain.com'
+      $httpBackend.flush()
+
+    # Group Members
+
+    it 'should create a member', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com/members"
+      data = {"kind":"admin#directory#member","email":"testuser@example.com","role":"MEMBER"}
+      $httpBackend.expectPOST(url, data, postHeaders).respond null
+      Directory.insertMembers 'testgroup@mydomain.com', data
+      $httpBackend.flush()
+
+    it 'should update a member', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com/members/testuser@mydomain.com"
+      data = {"kind":"admin#directory#member","role":"MEMBER"}
+      $httpBackend.expectPUT(url, data, putHeaders).respond null
+      Directory.updateMembers 'testgroup@mydomain.com', 'testuser@mydomain.com', data
+      $httpBackend.flush()
+
+    it 'should patch a member', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com/members/testuser@mydomain.com"
+      data = {"kind":"admin#directory#member","role":"MEMBER"}
+      $httpBackend.expectPATCH(url, data, putHeaders).respond null
+      Directory.patchMembers 'testgroup@mydomain.com', 'testuser@mydomain.com', data
+      $httpBackend.flush()
+
+    it 'should get a member', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com/members/testuser@mydomain.com"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      Directory.getMembers 'testgroup@mydomain.com', 'testuser@mydomain.com'
+      $httpBackend.flush()
+
+    it 'should list all members', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com/members"
+      $httpBackend.expectGET(url, getHeaders).respond null
+      Directory.listMembers 'testgroup@mydomain.com'
+      $httpBackend.flush()
+
+    it 'should delete a member', ->
+      url = "#{Directory.url}groups/testgroup@mydomain.com/members/testuser@mydomain.com"
+      $httpBackend.expectDELETE(url, getHeaders).respond null
+      Directory.deleteMembers 'testgroup@mydomain.com', 'testuser@mydomain.com'
+      $httpBackend.flush()
+

--- a/test/spec/DriveSpec.coffee
+++ b/test/spec/DriveSpec.coffee
@@ -12,7 +12,7 @@ describe 'GAPI', ->
     .value 'GoogleApp', 
       apiKey: '1234'
       clientId: 'abcd'
-    
+
 
   beforeEach module 'gapi'
 
@@ -27,16 +27,19 @@ describe 'GAPI', ->
       }
     }
 
-    getHeaders = deleteHeaders = patchHeaders = noContentHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
+    getHeaders = deleteHeaders = noContentHeaders =
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+
+    patchHeaders =
+      "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
     postHeaders = putHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
-      "Content-Type":"application/json;charset=utf-8"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
 
   afterEach ->
@@ -112,7 +115,7 @@ describe 'GAPI', ->
       url = "#{Drive.url}files?q=terms"
       $httpBackend.expectGET(url, getHeaders).respond null
       Drive.listFiles { q: 'terms' }
-      $httpBackend.flush()   
+      $httpBackend.flush()
 
     it 'should touch a file', ->
       url = "#{Drive.url}files/xyz/touch"

--- a/test/spec/GAPISpec.coffee
+++ b/test/spec/GAPISpec.coffee
@@ -28,15 +28,13 @@ describe 'GAPI', ->
     }
 
     getHeaders = deleteHeaders = patchHeaders = noContentHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
 
     postHeaders = putHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
-      "Content-Type":"application/json;charset=utf-8"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
     Service = new GAPI 'service', 'v1', 
       resources: [
@@ -188,9 +186,8 @@ describe 'GAPI', ->
     it 'should set a resource', ->
       url = "#{Service.url}resources/set"
       headers =
-        "Accept":"application/json, text/plain, */*"
-        "X-Requested-With":"XMLHttpRequest"
         "Authorization":"Bearer 1234abcd"
+        "Accept":"application/json, text/plain, */*"
       $httpBackend.expectPOST(url, undefined, headers).respond null
       Service.setResources()
       $httpBackend.flush()    
@@ -198,9 +195,8 @@ describe 'GAPI', ->
     it 'should unset a resource', ->
       url = "#{Service.url}resources/unset"
       headers =
-        "Accept":"application/json, text/plain, */*"
-        "X-Requested-With":"XMLHttpRequest"
         "Authorization":"Bearer 1234abcd"
+        "Accept":"application/json, text/plain, */*"
       $httpBackend.expectPOST(url, undefined, headers).respond null
       Service.unsetResources()
       $httpBackend.flush()  

--- a/test/spec/PlusSpec.coffee
+++ b/test/spec/PlusSpec.coffee
@@ -12,7 +12,7 @@ describe 'GAPI', ->
     .value 'GoogleApp', 
       apiKey: '1234'
       clientId: 'abcd'
-    
+
 
   beforeEach module 'gapi'
 
@@ -28,15 +28,13 @@ describe 'GAPI', ->
     }
 
     getHeaders = deleteHeaders = 
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
 
     postHeaders = putHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
-      "Content-Type":"application/json;charset=utf-8"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
 
 
   afterEach ->
@@ -86,7 +84,7 @@ describe 'GAPI', ->
       url = "#{Plus.url}people/xyz/people/visible?maxResults=5"
       $httpBackend.expectGET(url, getHeaders).respond null
       Plus.listPeople 'xyz', 'visible', { maxResults: 5 }
-      $httpBackend.flush()      
+      $httpBackend.flush()
 
 
     # ACTIVITIES
@@ -138,7 +136,7 @@ describe 'GAPI', ->
       url = "#{Plus.url}people/xyz/moments/vault"
       $httpBackend.expectGET(url, getHeaders).respond null
       Plus.listMoments 'xyz', 'vault'
-      $httpBackend.flush()       
+      $httpBackend.flush()
 
     it 'should delete a moment written by the app', ->
       url = "#{Plus.url}moments/123"

--- a/test/spec/YoutubeSpec.coffee
+++ b/test/spec/YoutubeSpec.coffee
@@ -12,7 +12,6 @@ describe 'GAPI', ->
     .value 'GoogleApp', 
       apiKey: '1234'
       clientId: 'abcd'
-    
 
   beforeEach module 'gapi'
 
@@ -28,16 +27,14 @@ describe 'GAPI', ->
     }
 
     getHeaders = deleteHeaders = 
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
       "Authorization":"Bearer 1234abcd"
+      "Accept":"application/json, text/plain, */*"
 
     postHeaders = putHeaders =
-      "Accept":"application/json, text/plain, */*"
-      "X-Requested-With":"XMLHttpRequest"
-      "Content-Type":"application/json;charset=utf-8"
       "Authorization":"Bearer 1234abcd"
-    
+      "Accept":"application/json, text/plain, */*"
+      "Content-Type":"application/json;charset=utf-8"
+
 
   afterEach ->
     $httpBackend.verifyNoOutstandingExpectation()
@@ -215,9 +212,8 @@ describe 'GAPI', ->
     it 'should set thumbnails', ->
       url = "#{Youtube.url}thumbnails/set?videoId=123"
       headers =
-        "Accept":"application/json, text/plain, */*"
-        "X-Requested-With":"XMLHttpRequest"
         "Authorization":"Bearer 1234abcd"      
+        "Accept":"application/json, text/plain, */*"
       $httpBackend.expectPOST(url, undefined, headers).respond null
       Youtube.setThumbnails({ videoId: '123' })
       $httpBackend.flush()      
@@ -263,9 +259,8 @@ describe 'GAPI', ->
     it 'should rate videos', ->
       url = "#{Youtube.url}videos/rate?id=xyz&rating=like"
       headers = 
-        "Accept":"application/json, text/plain, */*"
-        "X-Requested-With":"XMLHttpRequest"
         "Authorization":"Bearer 1234abcd"
+        "Accept":"application/json, text/plain, */*"
       $httpBackend.expectPOST(url, undefined, headers).respond null
       Youtube.rateVideos({ id: 'xyz', rating: 'like' })
       $httpBackend.flush()
@@ -282,9 +277,8 @@ describe 'GAPI', ->
     it 'should set watermarks', ->
       url = "#{Youtube.url}watermarks/set?channelId=123"
       headers =
-        "Accept":"application/json, text/plain, */*"
-        "X-Requested-With":"XMLHttpRequest"
         "Authorization":"Bearer 1234abcd"      
+        "Accept":"application/json, text/plain, */*"
       $httpBackend.expectPOST(url, undefined, headers).respond null
       Youtube.setWatermarks({ channelId: '123' })
       $httpBackend.flush()
@@ -292,16 +286,15 @@ describe 'GAPI', ->
     it 'should unset watermark', ->
       url = "#{Youtube.url}watermarks/unset?channelId=123"
       headers =
+        "Authorization":"Bearer 1234abcd"
         "Accept":"application/json, text/plain, */*"
-        "X-Requested-With":"XMLHttpRequest"
-        "Authorization":"Bearer 1234abcd"      
       $httpBackend.expectPOST(url, undefined, headers).respond null
       Youtube.unsetWatermarks({ channelId: '123' })
-      $httpBackend.flush()    
-    
+      $httpBackend.flush()
+
 
     # SEARCH
-    
+
     it 'should search', ->
       url = "#{Youtube.url}search?part=snippet&q=terms"
       $httpBackend.expectGET(url, getHeaders).respond null


### PR DESCRIPTION
Okay, lots of changes being submitted in this pull request.

The ngGAPI has now been updated and tested against the current google-provided javascript client, using OAuth2, and now supports the users, groups and members API's from the Admin SDK portion of the Google API.

Change Summary:

- Added API configs to support Admin Directory users, groups & members.
- Refactored OAuth2 wrapper and proved that it works in immediate=true mode.
- Updated existing unit tests to work with PhantomJS so it runs headless instead of in Chrome. (Feel free to change this back if you want)
- Added main: gapi.js to the bower file for better auto-injection support in other projects.
- Updated README.md file to include the fact that support for Admin SDK users, groups & members have been added.
- Changed references to console.log to $log.log so it doesn't break older versions of MSIE javascript.
- Fixed bug in cases where HTTP DELETE is called, where the transaction status could not be read by the caller to verify that the transaction succeeded. Google's API doesn't return any object when DELETE is successful, only a status code as part of the HTTP response. So the caller needs to have access to the transaction object, not just the expected response body object. (lines 133-136 in gapi.js)
- Added deferred.notify calls during OAuth2 process to help with communicating to the caller about what is happening during the OAuth2 process.
- The OAuth2 process will attempt login 4 times before sending deferred.reject.
- Cleaned up trailing white space throughout gapi.js and test spec files.
- Curly braces and white space changed to be more consistent with original code-style.

NOTE: When accessing any of the Admin SDK API's, (currently only users, groups and group members are supported), you need to do the following:

1. Access the Google Developer console and create an API Client ID for a Web Application. The interface keeps changing every few months, so hopefully the key words "Client ID, and Web Application" are enough to help you find what you're looking for. You want a key that allows you to restrict access by referrer domain name.

2. Log into your Google Apps domain account as an administrator. By the time you read this, the admin screen might have changed, but here's the path to what you need as of this writing:

Security -> Show More (at bottom) -> Advanced Settings -> Manage API client access

3. Once you're on that page, you need to enter your client ID and a comma-delimited list of scopes, as defined by the Admin SDK Documentation here: https://developers.google.com/admin-sdk/directory/v1/guides/authorizing

Once you have done that, you should be able to use your Client ID in your javascript call to the Google API as noted in the ngGAPI documentation that Christian wrote.