### PR TITLE
Failed login attempt should use immediate false as to show allow popup

### DIFF
--- a/gapi.js
+++ b/gapi.js
@@ -393,7 +393,7 @@ angular.module('gapi', [])
               gapi.auth.authorize({
                 client_id: app.clientId,
                 scope: app.scopes,
-                immediate: true
+                immediate: false
                 }, onAuth
               );
           }


### PR DESCRIPTION
See: https://developers.google.com/youtube/v3/code_samples/javascript

In particular:

// Handle the result of a gapi.auth.authorize() call.
function handleAuthResult(authResult) {
  if (authResult && !authResult.error) {
    // Authorization was successful. Hide authorization prompts and show
    // content that should be visible after authorization succeeds.
    $('.pre-auth').hide();
    $('.post-auth').show();
    loadAPIClientInterfaces();
  } else {
    // Make the #login-link clickable. Attempt a non-immediate OAuth 2.0
    // client flow. The current function is called when that flow completes.
    $('#login-link').click(function() {
      gapi.auth.authorize({
        client_id: OAUTH2_CLIENT_ID,
        scope: OAUTH2_SCOPES,
        **immediate: false**
        }, handleAuthResult);
    });
  }
}
