### PR TITLE
support API key for credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Be sure to include "gapi" as a dependency in your main app module.
 
 After you register your app in the [Google APIs Console](https://code.google.com/apis/console), configure ngGAPI with credentials and whatever scopes you need for your app.
 
+###with OAuth 2.0
     angular.module('myApp')
       .value('GoogleApp', {
-        apiKey: 'YOUR_API_KEY',
         clientId: 'YOUR_CLIENT_ID',
         scopes: [
           // whatever scopes you need for your app, for example:
@@ -44,7 +44,13 @@ After you register your app in the [Google APIs Console](https://code.google.com
           'https://www.googleapis.com/auth/userinfo.profile'
           // ...
         ]
-      })
+      });
+
+### with API keys
+    angular.module('myApp')
+      .value('GoogleApp', {
+        apiKey: 'YOUR_API_KEY'
+      });
 
 To use a specific service, inject it into your controllers by name. All GAPI methods return a promise.
 

--- a/gapi.js
+++ b/gapi.js
@@ -105,8 +105,20 @@ angular.module('gapi', [])
 
 
     /**
-     * OAuth 2.0 Signatures
+     * Credential exclusive way: API-key or Oauth 2.0
      */
+
+    function credential(options) {
+      if (GAPI.app.apiKey && !GAPI.app.clientId) {
+        setApiKey(options);
+      } else {
+        oauthHeader(options);
+      }
+    }
+
+    function setApiKey(options) {
+      options.params.key = GAPI.app.apiKey;
+    }
 
     function oauthHeader(options) {
       if (!options.headers) { options.headers = {}; }
@@ -126,7 +138,7 @@ angular.module('gapi', [])
     function request (config) {
       var deferred = $q.defer();
 
-      oauthHeader(config);
+      credential(config);
 
       function success(response) {
         $log.log('Request success: ', config, response);


### PR DESCRIPTION
If `clientId` is filled in `GoogleApp` whether with or without `apiKey`, `apiKey` will not be used.
(API works with OAuth flow)

But, only `apiKey` is filled in `GoogleApp`, OAuth flow will not be worked.
(API works with public API key)
